### PR TITLE
don't record schemas in map during inference

### DIFF
--- a/jsonschema/infer.go
+++ b/jsonschema/infer.go
@@ -231,7 +231,6 @@ func forType(t reflect.Type, seen map[reflect.Type]bool, ignore bool, schemas ma
 		s.Types = []string{"null", s.Type}
 		s.Type = ""
 	}
-	schemas[t] = s
 	return s, nil
 }
 

--- a/jsonschema/infer_test.go
+++ b/jsonschema/infer_test.go
@@ -338,3 +338,22 @@ func TestForWithCycle(t *testing.T) {
 func falseSchema() *jsonschema.Schema {
 	return &jsonschema.Schema{Not: &jsonschema.Schema{}}
 }
+
+func TestDupSchema(t *testing.T) {
+	// Verify that we don't repeat schema contents, even if we clone the actual schemas.
+	type args struct {
+		S string   `jsonschema:"str"`
+		A []string `jsonschema:"arr"`
+	}
+
+	s := forType[args](false)
+	if g, w := s.Properties["S"].Description, "str"; g != w {
+		t.Errorf("S: got %q, want %q", g, w)
+	}
+	if g, w := s.Properties["A"].Description, "arr"; g != w {
+		t.Errorf("A: got %q, want %q", g, w)
+	}
+	if g, w := s.Properties["A"].Items.Description, ""; g != w {
+		t.Errorf("A.items: got %q, want %q", g, w)
+	}
+}


### PR DESCRIPTION
The intial map of schemas should not be modified during inference. The schemas that get created during the walk may have keywords set, like "description", that should not appear elsewhere in the parent.

We don't need to add to the schemas map to detect cycles: we already have `seen` for that.

Fixes modelcontextprotocol/go-sdk#366.