### PR TITLE
infer: flatten embedded structs

### DIFF
--- a/jsonschema/infer.go
+++ b/jsonschema/infer.go
@@ -187,9 +187,11 @@ func forType(t reflect.Type, seen map[reflect.Type]bool, ignore bool, schemas ma
 		s.Type = "object"
 		// no additional properties are allowed
 		s.AdditionalProperties = falseSchema()
+		for _, field := range reflect.VisibleFields(t) {
+			if field.Anonymous {
+				continue
+			}
 
-		for i := range t.NumField() {
-			field := t.Field(i)
 			info := fieldJSONInfo(field)
 			if info.omit {
 				continue

--- a/jsonschema/infer_test.go
+++ b/jsonschema/infer_test.go
@@ -122,22 +122,17 @@ func TestFor(t *testing.T) {
 							Required:             []string{"B"},
 							AdditionalProperties: falseSchema(),
 						},
-						"S": {
-							Type: "object",
-							Properties: map[string]*schema{
-								"B": {Type: "integer", Description: "bdesc"},
-							},
-							Required:             []string{"B"},
-							AdditionalProperties: falseSchema(),
+						"B": {
+							Type:        "integer",
+							Description: "bdesc",
 						},
 					},
-					Required:             []string{"A", "S"},
+					Required:             []string{"A", "B"},
 					AdditionalProperties: falseSchema(),
 				},
 			},
 		}
 	}
-
 	run := func(t *testing.T, tt test) {
 		if diff := cmp.Diff(tt.want, tt.got, cmpopts.IgnoreUnexported(jsonschema.Schema{})); diff != "" {
 			t.Fatalf("For mismatch (-want +got):\n%s", diff)

--- a/jsonschema/validate.go
+++ b/jsonschema/validate.go
@@ -747,6 +747,9 @@ func structPropertiesOf(t reflect.Type) propertyMap {
 	}
 	props := map[string]reflect.StructField{}
 	for _, sf := range reflect.VisibleFields(t) {
+		if sf.Anonymous {
+			continue
+		}
 		info := fieldJSONInfo(sf)
 		if !info.omit {
 			props[info.name] = sf


### PR DESCRIPTION
This PR fixes an issue where embedded structs were not being flattened like encoding/json does. It now treats these embedded structs correctly.

For modelcontextprotocol/go-sdk#437