### PR TITLE
jsonschema: handle embedding of custom schemas

### DIFF
--- a/jsonschema/infer.go
+++ b/jsonschema/infer.go
@@ -187,9 +187,45 @@ func forType(t reflect.Type, seen map[reflect.Type]bool, ignore bool, schemas ma
 		s.Type = "object"
 		// no additional properties are allowed
 		s.AdditionalProperties = falseSchema()
+
+		// If skipPath is non-nil, it is path to an anonymous field whose
+		// schema has been replaced by a known schema.
+		var skipPath []int
 		for _, field := range reflect.VisibleFields(t) {
 			if field.Anonymous {
+				override := schemas[field.Type]
+				if override != nil {
+					skipPath = field.Index
+					s.Required = append(s.Required, override.Required...)
+					for name, prop := range override.Properties {
+						s.Properties[name] = prop.CloneSchemas()
+					}
+				}
 				continue
+			}
+
+			// Check to see if this field has been promoted from a replaced anonymous
+			// type.
+			if skipPath != nil {
+				skip := false
+				if len(field.Index) >= len(skipPath) {
+					skip = true
+					for i, index := range skipPath {
+						if field.Index[i] != index {
+							// If we're no longer in a subfield of
+							skip = false
+							break
+						}
+					}
+				}
+				if skip {
+					continue
+				} else {
+					// Anonymous fields are followed immediately by their promoted fields.
+					// Once we encounter a field that *isn't* promoted, we can stop
+					// checking.
+					skipPath = nil
+				}
 			}
 
 			info := fieldJSONInfo(field)

--- a/jsonschema/infer_test.go
+++ b/jsonschema/infer_test.go
@@ -175,18 +175,25 @@ func TestFor(t *testing.T) {
 func TestForType(t *testing.T) {
 	type schema = jsonschema.Schema
 
-	// ForType is virtually identical to For. Just test that options are handled properly.
-	opts := &jsonschema.ForOptions{
-		IgnoreInvalidTypes: true,
-		TypeSchemas: map[any]*jsonschema.Schema{
-			custom(0): {Type: "custom"},
-		},
+	type E struct {
+		G float64
 	}
 
 	type S struct {
 		I int
 		F func()
 		C custom
+		E
+		B bool
+	}
+
+	// ForType is virtually identical to For. Just test that options are handled properly.
+	opts := &jsonschema.ForOptions{
+		IgnoreInvalidTypes: true,
+		TypeSchemas: map[any]*jsonschema.Schema{
+			custom(0): {Type: "custom"},
+			E{}:       {Properties: map[string]*jsonschema.Schema{"G": {Type: "integer"}}},
+		},
 	}
 	got, err := jsonschema.ForType(reflect.TypeOf(S{}), opts)
 	if err != nil {
@@ -197,8 +204,10 @@ func TestForType(t *testing.T) {
 		Properties: map[string]*schema{
 			"I": {Type: "integer"},
 			"C": {Type: "custom"},
+			"G": {Type: "integer"},
+			"B": {Type: "boolean"},
 		},
-		Required:             []string{"I", "C"},
+		Required:             []string{"I", "C", "B"},
 		AdditionalProperties: falseSchema(),
 	}
 	if diff := cmp.Diff(want, got, cmpopts.IgnoreUnexported(schema{})); diff != "" {


### PR DESCRIPTION
When a type with a custom schema is embedded, honor its customization by taking (a clone of) its custom properties, and respecting its required properties.

Fixes #17