### PR TITLE
make struct validation fail

### DIFF
--- a/jsonschema/validate_test.go
+++ b/jsonschema/validate_test.go
@@ -260,10 +260,9 @@ func TestStructInstance(t *testing.T) {
 			t.Fatal(err)
 		}
 		err = res.Validate(instance)
-		if err == nil && !tt.want {
-			t.Errorf("succeeded unexpectedly\nschema = %s", tt.s.json())
-		} else if err != nil && tt.want {
-			t.Errorf("Validate: %v\nschema = %s", err, tt.s.json())
+		// Validating a struct always fails.
+		if err == nil {
+			t.Error("struct validation succeeded")
 		}
 	}
 }
@@ -442,8 +441,9 @@ func TestStructEmbedding(t *testing.T) {
 				t.Fatalf("schema.Resolve() failed: %v", err)
 			}
 			// Validate a correct instance against the generated schema.
-			if err := resolved.Validate(tc.validInstance); err != nil {
-				t.Errorf("resolved.Validate() failed on a valid instance: %v", err)
+			// Struct validation always fails.
+			if err := resolved.Validate(tc.validInstance); err == nil {
+				t.Error("struct validation succeeded")
 			}
 		})
 	}


### PR DESCRIPTION
Validating directly against a struct has problems (see #23). We could marshal it to JSON and then unmarshal to a map[string]any, but that is a performance footgun.
Have it fail for now.
We can add it back later if we choose to.

For #23.