### PR TITLE
jsonschema: change TypeSchemas key to reflect.Type

### DIFF
--- a/jsonschema/infer.go
+++ b/jsonschema/infer.go
@@ -26,12 +26,12 @@ type ForOptions struct {
 	IgnoreInvalidTypes bool
 
 	// TypeSchemas maps types to their schemas.
-	// If [For] encounters a type equal to a type of a key in this map, the
+	// If [For] encounters a type that is a key in this map, the
 	// corresponding value is used as the resulting schema (after cloning to
 	// ensure uniqueness).
 	// Types in this map override the default translations, as described
 	// in [For]'s documentation.
-	TypeSchemas map[any]*Schema
+	TypeSchemas map[reflect.Type]*Schema
 }
 
 // For constructs a JSON schema object for the given type argument.
@@ -78,9 +78,7 @@ func For[T any](opts *ForOptions) (*Schema, error) {
 	}
 	schemas := maps.Clone(initialSchemaMap)
 	// Add types from the options. They override the default ones.
-	for v, s := range opts.TypeSchemas {
-		schemas[reflect.TypeOf(v)] = s
-	}
+	maps.Copy(schemas, opts.TypeSchemas)
 	s, err := forType(reflect.TypeFor[T](), map[reflect.Type]bool{}, opts.IgnoreInvalidTypes, schemas)
 	if err != nil {
 		var z T
@@ -93,9 +91,7 @@ func For[T any](opts *ForOptions) (*Schema, error) {
 func ForType(t reflect.Type, opts *ForOptions) (*Schema, error) {
 	schemas := maps.Clone(initialSchemaMap)
 	// Add types from the options. They override the default ones.
-	for v, s := range opts.TypeSchemas {
-		schemas[reflect.TypeOf(v)] = s
-	}
+	maps.Copy(schemas, opts.TypeSchemas)
 	s, err := forType(t, map[reflect.Type]bool{}, opts.IgnoreInvalidTypes, schemas)
 	if err != nil {
 		return nil, fmt.Errorf("ForType(%s): %w", t, err)

--- a/jsonschema/infer_test.go
+++ b/jsonschema/infer_test.go
@@ -25,8 +25,8 @@ func forType[T any](ignore bool) *jsonschema.Schema {
 
 	opts := &jsonschema.ForOptions{
 		IgnoreInvalidTypes: ignore,
-		TypeSchemas: map[any]*jsonschema.Schema{
-			custom(0): {Type: "custom"},
+		TypeSchemas: map[reflect.Type]*jsonschema.Schema{
+			reflect.TypeFor[custom](): {Type: "custom"},
 		},
 	}
 	s, err = jsonschema.For[T](opts)
@@ -178,8 +178,8 @@ func TestForType(t *testing.T) {
 	// ForType is virtually identical to For. Just test that options are handled properly.
 	opts := &jsonschema.ForOptions{
 		IgnoreInvalidTypes: true,
-		TypeSchemas: map[any]*jsonschema.Schema{
-			custom(0): {Type: "custom"},
+		TypeSchemas: map[reflect.Type]*jsonschema.Schema{
+			reflect.TypeFor[custom](): {Type: "custom"},
 		},
 	}
 


### PR DESCRIPTION
BREAKING CHANGE

The key of ForOptions.TypeSchemas cannot be a value of the type, because some types can't be map keys.

So change it to reflect.Type.

Fixes #26.