### PR TITLE
Add range limits to inferred Schemas of int types. 

### DIFF
--- a/jsonschema/infer.go
+++ b/jsonschema/infer.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"math"
 	"math/big"
 	"reflect"
 	"regexp"
@@ -99,6 +100,11 @@ func ForType(t reflect.Type, opts *ForOptions) (*Schema, error) {
 	return s, nil
 }
 
+// Helper to create a *float64 pointer from a value
+func f64Ptr(f float64) *float64 {
+	return &f
+}
+
 func forType(t reflect.Type, seen map[reflect.Type]bool, ignore bool, schemas map[reflect.Type]*Schema) (*Schema, error) {
 	// Follow pointers: the schema for *T is almost the same as for T, except that
 	// an explicit JSON "null" is allowed for the pointer.
@@ -131,10 +137,42 @@ func forType(t reflect.Type, seen map[reflect.Type]bool, ignore bool, schemas ma
 	case reflect.Bool:
 		s.Type = "boolean"
 
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
-		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
-		reflect.Uintptr:
+	case reflect.Int, reflect.Int64:
 		s.Type = "integer"
+
+	case reflect.Uint, reflect.Uint64, reflect.Uintptr:
+		s.Type = "integer"
+		s.Minimum = f64Ptr(0)
+
+	case reflect.Int8:
+		s.Type = "integer"
+		s.Minimum = f64Ptr(math.MinInt8)
+		s.Maximum = f64Ptr(math.MaxInt8)
+
+	case reflect.Uint8:
+		s.Type = "integer"
+		s.Minimum = f64Ptr(0)
+		s.Maximum = f64Ptr(math.MaxUint8)
+
+	case reflect.Int16:
+		s.Type = "integer"
+		s.Minimum = f64Ptr(math.MinInt16)
+		s.Maximum = f64Ptr(math.MaxInt16)
+
+	case reflect.Uint16:
+		s.Type = "integer"
+		s.Minimum = f64Ptr(0)
+		s.Maximum = f64Ptr(math.MaxUint16)
+
+	case reflect.Int32:
+		s.Type = "integer"
+		s.Minimum = f64Ptr(math.MinInt32)
+		s.Maximum = f64Ptr(math.MaxInt32)
+
+	case reflect.Uint32:
+		s.Type = "integer"
+		s.Minimum = f64Ptr(0)
+		s.Maximum = f64Ptr(math.MaxUint32)
 
 	case reflect.Float32, reflect.Float64:
 		s.Type = "number"

--- a/jsonschema/infer_test.go
+++ b/jsonschema/infer_test.go
@@ -6,6 +6,7 @@ package jsonschema_test
 
 import (
 	"log/slog"
+	"math"
 	"math/big"
 	"reflect"
 	"strings"
@@ -49,12 +50,46 @@ func TestFor(t *testing.T) {
 		want *jsonschema.Schema
 	}
 
+	f64Ptr := jsonschema.Ptr[float64]
+
 	tests := func(ignore bool) []test {
 		return []test{
 			{"string", forType[string](ignore), &schema{Type: "string"}},
+			{
+				"int8",
+				forType[int8](ignore),
+				&schema{Type: "integer", Minimum: f64Ptr(math.MinInt8), Maximum: f64Ptr(math.MaxInt8)},
+			},
+			{
+				"uint8",
+				forType[uint8](ignore),
+				&schema{Type: "integer", Minimum: f64Ptr(0), Maximum: f64Ptr(math.MaxUint8)},
+			},
+			{
+				"int16",
+				forType[int16](ignore),
+				&schema{Type: "integer", Minimum: f64Ptr(math.MinInt16), Maximum: f64Ptr(math.MaxInt16)},
+			},
+			{
+				"uint16",
+				forType[uint16](ignore),
+				&schema{Type: "integer", Minimum: f64Ptr(0), Maximum: f64Ptr(math.MaxUint16)},
+			},
+			{
+				"int32",
+				forType[int32](ignore),
+				&schema{Type: "integer", Minimum: f64Ptr(math.MinInt32), Maximum: f64Ptr(math.MaxInt32)},
+			},
+			{
+				"uint32",
+				forType[uint32](ignore),
+				&schema{Type: "integer", Minimum: f64Ptr(0), Maximum: f64Ptr(math.MaxUint32)},
+			},
+			{"int64", forType[int64](ignore), &schema{Type: "integer"}},
+			{"uint64", forType[uint64](ignore), &schema{Type: "integer", Minimum: f64Ptr(0)}},
 			{"int", forType[int](ignore), &schema{Type: "integer"}},
-			{"int16", forType[int16](ignore), &schema{Type: "integer"}},
-			{"uint32", forType[int16](ignore), &schema{Type: "integer"}},
+			{"uint", forType[uint](ignore), &schema{Type: "integer", Minimum: f64Ptr(0)}},
+			{"uintptr", forType[uintptr](ignore), &schema{Type: "integer", Minimum: f64Ptr(0)}},
 			{"float64", forType[float64](ignore), &schema{Type: "number"}},
 			{"bool", forType[bool](ignore), &schema{Type: "boolean"}},
 			{"time", forType[time.Time](ignore), &schema{Type: "string"}},
@@ -64,6 +99,10 @@ func TestFor(t *testing.T) {
 			{"intmap", forType[map[string]int](ignore), &schema{
 				Type:                 "object",
 				AdditionalProperties: &schema{Type: "integer"},
+			}},
+			{"int8map", forType[map[string]int8](ignore), &schema{
+				Type:                 "object",
+				AdditionalProperties: &schema{Type: "integer", Minimum: f64Ptr(math.MinInt8), Maximum: f64Ptr(math.MaxInt8)},
 			}},
 			{"anymap", forType[map[string]any](ignore), &schema{
 				Type:                 "object",


### PR DESCRIPTION
When inferring a schema, set the Minimum and Maximum properties for integer types.

For #12 