### PR TITLE
chore: fix Github issue tracker link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project uses the [GitHub issue
 tracker](https://github.com/google/jsonschema-go/issues) for bug reports, feature requests, and other issues. 
 
 Please [report
-bugs](https://github.com/google/jsonschema-go/issues/new). If the SDK is
+bugs](https://github.com/google/jsonschema-go/issues/new?template=bug_report.md). If the SDK is
 not working as you expected, it is likely due to a bug or inadequate
 documentation, and reporting an issue will help us address this shortcoming.
 


### PR DESCRIPTION
Github issue tracker link in README is invalid