### PR TITLE
feat: add nested subschema defaults application

### DIFF
--- a/jsonschema/validate.go
+++ b/jsonschema/validate.go
@@ -670,7 +670,7 @@ func (st *state) applyDefaults(instancep reflect.Value, schema *Schema) (err err
 					}
 					instance.SetMapIndex(reflect.ValueOf(prop), lvalue.Elem())
 				} else if val.IsValid() {
-					// Recurse into an existing sub-instance if it is object-like.
+					// Recurse into an existing sub-instance.
 					// MapIndex returns a non-addressable value; copy into an addressable lvalue, recurse, then set back.
 					lvalue := reflect.New(instance.Type().Elem())
 					// Initialize the lvalue with current value.


### PR DESCRIPTION
r? @jba 

## What does this PR do?
Adds nested subschema recursion to `ApplyDefaults`.

## Why is this needed?
It addresses issue https://github.com/google/jsonschema-go/issues/34.

## What Changed?
* `ApplyDefaults` now recurses into object properties to fill deeper subschema defaults.
* Creates empty containers when a property is missing but descendants have defaults.
* Added plenty of test cases covering nested subschema default application

This makes no changes to arrays or $ref/$dynamicRef handling. Only addresses object-like schemas without resolving refs.