### PR TITLE
fix: infer - missing nullable type for non Go types

### DIFF
--- a/jsonschema/infer_test.go
+++ b/jsonschema/infer_test.go
@@ -223,13 +223,21 @@ func TestForType(t *testing.T) {
 		B int     // hidden by S.B
 	}
 
+	type M1 int
+	type M2 int
+
 	type S struct {
-		I int
-		F func()
-		C custom
-		P *custom
+		I  int
+		F  func()
+		C  custom
+		P  *custom
+		PP **custom
 		E
-		B bool
+		B   bool
+		M1  M1
+		PM1 *M1
+		M2  M2
+		PM2 *M2
 	}
 
 	opts := &jsonschema.ForOptions{
@@ -243,6 +251,8 @@ func TestForType(t *testing.T) {
 					"B": {Type: "integer"},
 				},
 			},
+			reflect.TypeFor[M1](): {Types: []string{"custom1", "custom2"}},
+			reflect.TypeFor[M2](): {Types: []string{"null", "custom3", "custom4"}},
 		},
 	}
 	got, err := jsonschema.ForType(reflect.TypeOf(S{}), opts)
@@ -252,13 +262,18 @@ func TestForType(t *testing.T) {
 	want := &schema{
 		Type: "object",
 		Properties: map[string]*schema{
-			"I": {Type: "integer"},
-			"C": {Type: "custom"},
-			"P": {Types: []string{"null", "custom"}},
-			"G": {Type: "integer"},
-			"B": {Type: "boolean"},
+			"I":   {Type: "integer"},
+			"C":   {Type: "custom"},
+			"P":   {Types: []string{"null", "custom"}},
+			"PP":  {Types: []string{"null", "custom"}},
+			"G":   {Type: "integer"},
+			"B":   {Type: "boolean"},
+			"M1":  {Types: []string{"custom1", "custom2"}},
+			"PM1": {Types: []string{"null", "custom1", "custom2"}},
+			"M2":  {Types: []string{"null", "custom3", "custom4"}},
+			"PM2": {Types: []string{"null", "custom3", "custom4"}},
 		},
-		Required:             []string{"I", "C", "P", "B"},
+		Required:             []string{"I", "C", "P", "PP", "B", "M1", "PM1", "M2", "PM2"},
 		AdditionalProperties: falseSchema(),
 	}
 	if diff := cmp.Diff(want, got, cmpopts.IgnoreUnexported(schema{})); diff != "" {


### PR DESCRIPTION
When providing a struct containing an attribute wich the type is a pointer to a non-native type, the infer analysis wouldn't set the output schema type as nullable for this attribute.

Example:

```go
type example struct {
	Value *time.Time `json:"value"`
}

func main() {
	schema, err := jsonschema.For[example](&jsonschema.ForOptions{})
	if err != nil {
		fmt.Fprintf(os.Stderr, "failed to generate JSON schema: %v", err)
		os.Exit(1)
	}
	encoded, err := json.Marshal(schema)
	if err != nil {
		fmt.Fprintf(os.Stderr, "failed to encode JSON schema: %v", err)
		os.Exit(1)
	}
	fmt.Println(string(encoded))
}
```

This would generate:
```json
{"type":"object","required":["value"],"properties":{"value":{"type":"string"}},"additionalProperties":false}
```

Using the `TypeSchemas` option will have the same result, since [only the element is analysed](https://github.com/google/jsonschema-go/blob/3ba200528d086ef03a2d8e8d4f7d7146400e342f/jsonschema/infer.go#L114):

```go
schema, err := jsonschema.For[example](&jsonschema.ForOptions{
	TypeSchemas: map[reflect.Type]*jsonschema.Schema{
		reflect.TypeFor[*time.Time](): {
			Types: []string{"null", "string"},
		},
	},
})
```

With this patch the null flag will be checked even when there's a match with pre-registered types, resulting on the following output:

```json
{"type":"object","required":["value"],"properties":{"value":{"type":["null","string"]}},"additionalProperties":false}
```

Resolves #41