### PR TITLE
marshal empty properties map as empty object

### DIFF
--- a/jsonschema/schema.go
+++ b/jsonschema/schema.go
@@ -101,7 +101,7 @@ type Schema struct {
 	MaxProperties         *int                `json:"maxProperties,omitempty"`
 	Required              []string            `json:"required,omitempty"`
 	DependentRequired     map[string][]string `json:"dependentRequired,omitempty"`
-	Properties            map[string]*Schema  `json:"properties,omitempty"`
+	Properties            map[string]*Schema  `json:"properties"`
 	PatternProperties     map[string]*Schema  `json:"patternProperties,omitempty"`
 	AdditionalProperties  *Schema             `json:"additionalProperties,omitempty"`
 	PropertyNames         *Schema             `json:"propertyNames,omitempty"`


### PR DESCRIPTION
Some MCP clients want a "properties" keyword on a tool schema, even if it is empty.
For an example, see https://github.com/golang/go/issues/76777.

This PR makes an empty map in Schema.Properties marshal as "{}" instead of omitting it.

Technically, this is a breaking change, but it is extremely unlikely that it will matter to anyone (except in a good way).