### PR TITLE
marshal empty properties map as empty object (for real)

### DIFF
--- a/jsonschema/schema.go
+++ b/jsonschema/schema.go
@@ -101,7 +101,7 @@ type Schema struct {
 	MaxProperties         *int                `json:"maxProperties,omitempty"`
 	Required              []string            `json:"required,omitempty"`
 	DependentRequired     map[string][]string `json:"dependentRequired,omitempty"`
-	Properties            map[string]*Schema  `json:"properties"`
+	Properties            map[string]*Schema  `json:"properties,omitempty"`
 	PatternProperties     map[string]*Schema  `json:"patternProperties,omitempty"`
 	AdditionalProperties  *Schema             `json:"additionalProperties,omitempty"`
 	PropertyNames         *Schema             `json:"propertyNames,omitempty"`
@@ -285,7 +285,8 @@ func (s Schema) MarshalJSON() ([]byte, error) {
 		Items:                items,
 		schemaWithoutMethods: (*schemaWithoutMethods)(&s),
 	}
-	if len(s.Properties) > 0 {
+	// Marshal properties, even if the empty map (but not nil).
+	if s.Properties != nil {
 		ms.Properties = orderedProperties{
 			props: s.Properties,
 			order: s.PropertyOrder,

--- a/jsonschema/schema_test.go
+++ b/jsonschema/schema_test.go
@@ -162,6 +162,19 @@ func TestMarshalJSONConsistency(t *testing.T) {
 			t.Errorf("Interface value marshaling mismatch\ngot:  %s\nwant: %s", got, expectedJSON)
 		}
 	})
+
+	t.Run("EmptyPropertiesMap", func(t *testing.T) {
+		// Test that an empty map in Properties marshals as "{}".
+		s := &Schema{Type: "object", Properties: map[string]*Schema{}}
+		got, err := json.Marshal(s)
+		if err != nil {
+			t.Fatalf("Failed to marshal interface value: %v", err)
+		}
+		want := `{"type":"object","properties":{}}`
+		if string(got) != want {
+			t.Errorf("\ngot  %s\nwant %s", got, want)
+		}
+	})
 }
 
 func TestGoRoundTrip(t *testing.T) {


### PR DESCRIPTION
#59 was broken. This does it right (with a test).