### PR TITLE
feat: Handle json.Number values

### DIFF
--- a/jsonschema/util.go
+++ b/jsonschema/util.go
@@ -19,6 +19,10 @@ import (
 	"sync"
 )
 
+var (
+	jsonNumberType = reflect.TypeFor[json.Number]()
+)
+
 // Equal reports whether two Go values representing JSON values are equal according
 // to the JSON Schema spec.
 // The values must not contain cycles.
@@ -264,6 +268,14 @@ func jsonType(v reflect.Value) (string, bool) {
 			return "integer", true
 		}
 		return "number", true
+	}
+	if v.Type() == jsonNumberType {
+		if value, err := v.Interface().(json.Number).Float64(); err == nil {
+			if _, f := math.Modf(value); f == 0 {
+				return "integer", true
+			}
+			return "number", true
+		}
 	}
 	switch v.Kind() {
 	case reflect.Bool:

--- a/jsonschema/util_test.go
+++ b/jsonschema/util_test.go
@@ -48,33 +48,65 @@ func TestEqual(t *testing.T) {
 }
 
 func TestJSONType(t *testing.T) {
-	for _, tt := range []struct {
-		val  string
-		want string
-	}{
-		{`null`, "null"},
-		{`0`, "integer"},
-		{`0.0`, "integer"},
-		{`1e2`, "integer"},
-		{`0.1`, "number"},
-		{`""`, "string"},
-		{`true`, "boolean"},
-		{`[]`, "array"},
-		{`{}`, "object"},
-	} {
-		var val any
-		if err := json.Unmarshal([]byte(tt.val), &val); err != nil {
-			t.Fatal(err)
+	t.Run("normal unmarshal", func(t *testing.T) {
+		for _, tt := range []struct {
+			val  string
+			want string
+		}{
+			{`null`, "null"},
+			{`0`, "integer"},
+			{`0.0`, "integer"},
+			{`1e2`, "integer"},
+			{`0.1`, "number"},
+			{`""`, "string"},
+			{`true`, "boolean"},
+			{`[]`, "array"},
+			{`{}`, "object"},
+		} {
+			var val any
+			if err := json.Unmarshal([]byte(tt.val), &val); err != nil {
+				t.Fatal(err)
+			}
+			got, ok := jsonType(reflect.ValueOf(val))
+			if !ok {
+				t.Fatalf("jsonType failed on %q", tt.val)
+			}
+			if got != tt.want {
+				t.Errorf("%s: got %q, want %q", tt.val, got, tt.want)
+			}
 		}
-		got, ok := jsonType(reflect.ValueOf(val))
-		if !ok {
-			t.Fatalf("jsonType failed on %q", tt.val)
-		}
-		if got != tt.want {
-			t.Errorf("%s: got %q, want %q", tt.val, got, tt.want)
-		}
+	})
 
-	}
+	t.Run("with UseNumber", func(t *testing.T) {
+		for _, tt := range []struct {
+			val  string
+			want string
+		}{
+			{`null`, "null"},
+			{`0`, "integer"},
+			{`0.0`, "integer"},
+			{`1e2`, "integer"},
+			{`0.1`, "number"},
+			{`""`, "string"},
+			{`true`, "boolean"},
+			{`[]`, "array"},
+			{`{}`, "object"},
+		} {
+			var val any
+			decoder := json.NewDecoder(strings.NewReader(tt.val))
+			decoder.UseNumber()
+			if err := decoder.Decode(&val); err != nil {
+				t.Fatal(err)
+			}
+			got, ok := jsonType(reflect.ValueOf(val))
+			if !ok {
+				t.Fatalf("jsonType failed on %q", tt.val)
+			}
+			if got != tt.want {
+				t.Errorf("%s: got %q, want %q", tt.val, got, tt.want)
+			}
+		}
+	})
 }
 
 func TestHash(t *testing.T) {


### PR DESCRIPTION
If a json.Number value is given to the schema to validate it will currently treat it as a "string" because of the underlying type. It might make more sense to check for this specific value and then handle it the same way you would handle a float64 that would have been received from the traditional json.Unmarshal for a numeric value.