### PR TITLE
resolve default through ref unless default exists at same level

### DIFF
--- a/jsonschema/validate.go
+++ b/jsonschema/validate.go
@@ -725,10 +725,13 @@ func (st *state) applyDefaults(instancep reflect.Value, schema *Schema) (err err
 			}
 
 			subschemaDefault := subschema.Default
-			subschemaInfo := st.rs.resolvedInfos[subschema]
 
-			if subschemaDefault == nil && subschemaInfo.resolvedRef != nil {
-				subschemaDefault = subschemaInfo.resolvedRef.Default
+			if st.rs.resolvedInfos != nil {
+				subschemaInfo := st.rs.resolvedInfos[subschema]
+
+				if subschemaDefault == nil && subschemaInfo != nil && subschemaInfo.resolvedRef != nil {
+					subschemaDefault = subschemaInfo.resolvedRef.Default
+				}
 			}
 
 			val := property(instance, prop)

--- a/jsonschema/validate.go
+++ b/jsonschema/validate.go
@@ -723,15 +723,23 @@ func (st *state) applyDefaults(instancep reflect.Value, schema *Schema) (err err
 			if schemaInfo.isRequired[prop] {
 				continue
 			}
+
+			subschemaDefault := subschema.Default
+			subschemaInfo := st.rs.resolvedInfos[subschema]
+
+			if subschemaDefault == nil && subschemaInfo.resolvedRef != nil {
+				subschemaDefault = subschemaInfo.resolvedRef.Default
+			}
+
 			val := property(instance, prop)
 			switch instance.Kind() {
 			case reflect.Map:
 				// If there is a default for this property, and the map key is missing,
 				// set the map value to the default.
-				if subschema.Default != nil && !val.IsValid() {
+				if subschemaDefault != nil && !val.IsValid() {
 					// Create an lvalue, since map values aren't addressable.
 					lvalue := reflect.New(instance.Type().Elem())
-					if err := json.Unmarshal(subschema.Default, lvalue.Interface()); err != nil {
+					if err := json.Unmarshal(subschemaDefault, lvalue.Interface()); err != nil {
 						return err
 					}
 					// Recurse unconditionally; applyDefaults will only act on object-like values.

--- a/jsonschema/validate.go
+++ b/jsonschema/validate.go
@@ -728,7 +728,6 @@ func (st *state) applyDefaults(instancep reflect.Value, schema *Schema) (err err
 
 			if st.rs.resolvedInfos != nil {
 				subschemaInfo := st.rs.resolvedInfos[subschema]
-
 				if subschemaDefault == nil && subschemaInfo != nil && subschemaInfo.resolvedRef != nil {
 					subschemaDefault = subschemaInfo.resolvedRef.Default
 				}

--- a/jsonschema/validate_test.go
+++ b/jsonschema/validate_test.go
@@ -264,6 +264,67 @@ func TestApplyNestedDefaults(t *testing.T) {
 	}
 }
 
+func TestApplyDefaultsInRef(t *testing.T) {
+	schema := &Schema{
+		Type: "object",
+		Properties: map[string]*Schema{
+			"A": {Ref: "#/definitions/A"},
+		},
+		Definitions: map[string]*Schema{
+			"A": {
+				Type:    "array",
+				Default: mustMarshal([]any{}),
+			},
+		},
+	}
+	instancep := &map[string]any{}
+	want := map[string]any{"A": []any{}}
+
+	rs, err := schema.Resolve(&ResolveOptions{ValidateDefaults: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rs.ApplyDefaults(instancep); err != nil {
+		t.Fatal(err)
+	}
+	got := reflect.ValueOf(instancep).Elem().Interface()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("defaults in ref:\n got  %#v\n want %#v", got, want)
+	}
+}
+
+func TestApplyDefaultsOverrideRef(t *testing.T) {
+	schema := &Schema{
+		Type: "object",
+		Properties: map[string]*Schema{
+			"A": {
+				Ref:     "#/definitions/A",
+				Default: mustMarshal([]any{1, 2, 3}),
+			},
+		},
+		Definitions: map[string]*Schema{
+			"A": {
+				Type:    "array",
+				Default: mustMarshal([]any{}),
+			},
+		},
+	}
+	instancep := &map[string]any{}
+	want := map[string]any{"A": []any{float64(1), float64(2), float64(3)}}
+
+	rs, err := schema.Resolve(&ResolveOptions{ValidateDefaults: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rs.ApplyDefaults(instancep); err != nil {
+		t.Fatal(err)
+	}
+	got := reflect.ValueOf(instancep).Elem().Interface()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("defaults in ref:\n got  %#v\n want %#v", got, want)
+	}
+}
+
 func TestStructInstance(t *testing.T) {
 	instance := struct {
 		I int

--- a/jsonschema/validate_test.go
+++ b/jsonschema/validate_test.go
@@ -268,8 +268,8 @@ func TestApplyDefaultsWithRef(t *testing.T) {
 	for _, tt := range []struct {
 		name      string
 		schema    Schema
-		instancep any
-		want      any
+		instancep *map[string]any
+		want      map[string]any
 	}{
 		{
 			name: "RefHasDefault",
@@ -317,8 +317,8 @@ func TestApplyDefaultsWithRef(t *testing.T) {
 			if err := res.ApplyDefaults(tt.instancep); err != nil {
 				t.Fatal(err)
 			}
-			got := reflect.ValueOf(tt.instancep).Elem().Interface()
-			if diff := cmp.Diff(tt.want, got, cmpopts.IgnoreUnexported(Schema{})); diff != "" {
+
+			if diff := cmp.Diff(&tt.want, tt.instancep, cmpopts.IgnoreUnexported(Schema{})); diff != "" {
 				t.Fatalf("Schema mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/jsonschema/validate_test.go
+++ b/jsonschema/validate_test.go
@@ -264,64 +264,64 @@ func TestApplyNestedDefaults(t *testing.T) {
 	}
 }
 
-func TestApplyDefaultsInRef(t *testing.T) {
-	schema := &Schema{
-		Type: "object",
-		Properties: map[string]*Schema{
-			"A": {Ref: "#/definitions/A"},
-		},
-		Definitions: map[string]*Schema{
-			"A": {
-				Type:    "array",
-				Default: mustMarshal([]any{}),
+func TestApplyDefaultsWithRef(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		schema    Schema
+		instancep any
+		want      any
+	}{
+		{
+			name: "RefHasDefault",
+			schema: Schema{
+				Type: "object",
+				Properties: map[string]*Schema{
+					"A": {Ref: "#/definitions/A"},
+				},
+				Definitions: map[string]*Schema{
+					"A": {
+						Type:    "array",
+						Default: mustMarshal([]any{}),
+					},
+				},
 			},
+			instancep: &map[string]any{},
+			want:      map[string]any{"A": []any{}},
 		},
-	}
-	instancep := &map[string]any{}
-	want := map[string]any{"A": []any{}}
-
-	rs, err := schema.Resolve(&ResolveOptions{ValidateDefaults: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := rs.ApplyDefaults(instancep); err != nil {
-		t.Fatal(err)
-	}
-	got := reflect.ValueOf(instancep).Elem().Interface()
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("defaults in ref:\n got  %#v\n want %#v", got, want)
-	}
-}
-
-func TestApplyDefaultsOverrideRef(t *testing.T) {
-	schema := &Schema{
-		Type: "object",
-		Properties: map[string]*Schema{
-			"A": {
-				Ref:     "#/definitions/A",
-				Default: mustMarshal([]any{1, 2, 3}),
+		{
+			name: "RefDefaultOverriden",
+			schema: Schema{
+				Type: "object",
+				Properties: map[string]*Schema{
+					"A": {
+						Ref:     "#/definitions/A",
+						Default: mustMarshal([]any{1, 2, 3}),
+					},
+				},
+				Definitions: map[string]*Schema{
+					"A": {
+						Type:    "array",
+						Default: mustMarshal([]any{}),
+					},
+				},
 			},
+			instancep: &map[string]any{},
+			want:      map[string]any{"A": []any{float64(1), float64(2), float64(3)}},
 		},
-		Definitions: map[string]*Schema{
-			"A": {
-				Type:    "array",
-				Default: mustMarshal([]any{}),
-			},
-		},
-	}
-	instancep := &map[string]any{}
-	want := map[string]any{"A": []any{float64(1), float64(2), float64(3)}}
-
-	rs, err := schema.Resolve(&ResolveOptions{ValidateDefaults: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := rs.ApplyDefaults(instancep); err != nil {
-		t.Fatal(err)
-	}
-	got := reflect.ValueOf(instancep).Elem().Interface()
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("defaults in ref:\n got  %#v\n want %#v", got, want)
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := tt.schema.Resolve(&ResolveOptions{ValidateDefaults: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := res.ApplyDefaults(tt.instancep); err != nil {
+				t.Fatal(err)
+			}
+			got := reflect.ValueOf(tt.instancep).Elem().Interface()
+			if diff := cmp.Diff(tt.want, got, cmpopts.IgnoreUnexported(Schema{})); diff != "" {
+				t.Fatalf("Schema mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This library does not follow a `$ref` when applying defaults. I've added test cases for the two scenarios I can think of where there is both and `$ref` (with it's own `default`) and a `default` at the same level and when there is just a `$ref` with it's own `default` inside. In this case the solution I have implemented only searches the `$ref` if there is no `default` on the subschema. Essentially meaning a subschema can override a `default` inside the `$ref`.

I did look through the JSONSchema reference about how `default` should be handled and found this blurb so I guess it is up to tooling.

> the JSON Schema specification does not provide any guidance on how this keyword should be used

 Either way is trivial to implement but it should at least be noted I guess.