### PR TITLE
fix: infer - support map with non-string key type

### DIFF
--- a/jsonschema/infer.go
+++ b/jsonschema/infer.go
@@ -7,6 +7,7 @@
 package jsonschema
 
 import (
+	"encoding"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -197,13 +198,11 @@ func forType(t reflect.Type, seen map[reflect.Type]bool, ignore bool, schemas ma
 		// Unrestricted
 
 	case reflect.Map:
-		if t.Key().Kind() != reflect.String {
+		if t.Key().Kind() != reflect.String && !t.Key().Implements(reflect.TypeFor[encoding.TextMarshaler]()) {
 			if ignore {
 				return nil, nil // ignore
 			}
 			return nil, fmt.Errorf("unsupported map key type %v", t.Key().Kind())
-		}
-		if t.Key().Kind() != reflect.String {
 		}
 		s.Type = "object"
 		s.AdditionalProperties, err = forType(t.Elem(), seen, ignore, schemas)

--- a/jsonschema/infer_test.go
+++ b/jsonschema/infer_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"math/big"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -19,6 +20,10 @@ import (
 )
 
 type custom int
+
+func (c custom) MarshalText() ([]byte, error) {
+	return []byte(strconv.FormatInt(int64(c), 10)), nil
+}
 
 func forType[T any](ignore bool) *jsonschema.Schema {
 	var s *jsonschema.Schema
@@ -108,6 +113,10 @@ func TestFor(t *testing.T) {
 			{"anymap", forType[map[string]any](ignore), &schema{
 				Type:                 "object",
 				AdditionalProperties: &schema{},
+			}},
+			{"custommap", forType[map[custom]string](ignore), &schema{
+				Type:                 "object",
+				AdditionalProperties: &schema{Type: "string"},
 			}},
 			{
 				"struct",


### PR DESCRIPTION
Accept a non-string key for a map if it implements the `encoding.TextMarshaler` interface. This should comply with the standard library behaviour:

> The map's key type must either be a string, an integer type, or implement encoding.TextMarshaler.

https://pkg.go.dev/encoding/json#Marshal