### PR TITLE
feat: add RegexpCompiler option for custom regexp engines

### DIFF
--- a/jsonschema/doc.go
+++ b/jsonschema/doc.go
@@ -78,9 +78,10 @@ Use the "jsonschema" struct tag to provide a description for the property:
 
 # Deviations from the specification
 
-Regular expressions are processed with Go's regexp package, which differs
-from ECMA 262, most significantly in not supporting back-references.
-See [this table of differences] for more.
+Regular expressions are processed with Go's [regexp] package by default, which
+differs from ECMA 262, most significantly in not supporting back-references or
+lookahead. See [this table of differences] for more. To use a PCRE-compatible
+engine, provide a custom [RegexpCompiler] in [ResolveOptions].
 
 The "format" keyword described in [section 7 of the validation spec] is recorded
 in the Schema, but is ignored during validation.

--- a/jsonschema/resolve.go
+++ b/jsonschema/resolve.go
@@ -96,8 +96,8 @@ type resolvedInfo struct {
 	isRequired map[string]bool
 
 	// Compiled regexps.
-	pattern           *regexp.Regexp
-	patternProperties map[*regexp.Regexp]*Schema
+	pattern           Regexp
+	patternProperties map[Regexp]*Schema
 
 	// Map from anchors to subschemas.
 	anchors map[string]anchorInfo
@@ -118,6 +118,19 @@ func (r *Resolved) schemaString(s *Schema) string {
 	}
 	return "<anonymous schema>"
 }
+
+// A Regexp is a compiled regular expression.
+// It is used by the validator to match strings against patterns.
+type Regexp interface {
+	MatchString(s string) bool
+}
+
+// A RegexpCompiler compiles a regular expression pattern string into a [Regexp].
+// The default compiler uses Go's [regexp] package. Provide a custom compiler
+// for Perl-compatible features like lookahead; see the [regexp2 package].
+//
+// [regexp2 package]: https://github.com/dlclark/regexp2
+type RegexpCompiler func(pattern string) (Regexp, error)
 
 // A Loader reads and unmarshals the schema at uri, if any.
 type Loader func(uri *url.URL) (*Schema, error)
@@ -142,6 +155,10 @@ type ResolveOptions struct {
 	//
 	// [JSON Schema specification]: https://json-schema.org/understanding-json-schema/reference/annotations
 	ValidateDefaults bool
+	// RegexpCompiler compiles regular expression patterns used in "pattern" and
+	// "patternProperties" keywords. If nil, Go's [regexp.Compile] is used.
+	// Provide a custom compiler for Perl-compatible features like lookahead.
+	RegexpCompiler RegexpCompiler
 }
 
 // Resolve resolves all references within the schema and performs other tasks that
@@ -182,6 +199,12 @@ func (root *Schema) Resolve(opts *ResolveOptions) (*Resolved, error) {
 		}
 	}
 
+	if r.opts.RegexpCompiler == nil {
+		r.opts.RegexpCompiler = func(pattern string) (Regexp, error) {
+			return regexp.Compile(pattern)
+		}
+	}
+
 	resolved, err := r.resolve(root, base)
 	if err != nil {
 		return nil, err
@@ -210,7 +233,7 @@ func (r *resolver) resolve(s *Schema, baseURI *url.URL) (*Resolved, error) {
 	}
 	rs := newResolved(s)
 
-	if err := s.check(rs.resolvedInfos); err != nil {
+	if err := s.check(rs.resolvedInfos, r.opts.RegexpCompiler); err != nil {
 		return nil, err
 	}
 
@@ -230,7 +253,7 @@ func (r *resolver) resolve(s *Schema, baseURI *url.URL) (*Resolved, error) {
 	return rs, nil
 }
 
-func (root *Schema) check(infos map[*Schema]*resolvedInfo) error {
+func (root *Schema) check(infos map[*Schema]*resolvedInfo, compile RegexpCompiler) error {
 	// Check for structural validity. Do this first and fail fast:
 	// bad structure will cause other code to panic.
 	if err := root.checkStructure(infos); err != nil {
@@ -241,7 +264,7 @@ func (root *Schema) check(infos map[*Schema]*resolvedInfo) error {
 	report := func(err error) { errs = append(errs, err) }
 
 	for ss := range root.all() {
-		ss.checkLocal(report, infos)
+		ss.checkLocal(report, infos, compile)
 	}
 	return errors.Join(errs...)
 }
@@ -313,7 +336,7 @@ func (root *Schema) checkStructure(infos map[*Schema]*resolvedInfo) error {
 // Since checking a regexp involves compiling it, checkLocal saves those compiled regexps
 // in the schema for later use.
 // It appends the errors it finds to errs.
-func (s *Schema) checkLocal(report func(error), infos map[*Schema]*resolvedInfo) {
+func (s *Schema) checkLocal(report func(error), infos map[*Schema]*resolvedInfo, compile RegexpCompiler) {
 	addf := func(format string, args ...any) {
 		msg := fmt.Sprintf(format, args...)
 		report(fmt.Errorf("jsonschema.Schema: %s: %s", s, msg))
@@ -343,7 +366,7 @@ func (s *Schema) checkLocal(report func(error), infos map[*Schema]*resolvedInfo)
 
 	// Check and compile regexps.
 	if s.Pattern != "" {
-		re, err := regexp.Compile(s.Pattern)
+		re, err := compile(s.Pattern)
 		if err != nil {
 			addf("pattern: %v", err)
 		} else {
@@ -351,9 +374,9 @@ func (s *Schema) checkLocal(report func(error), infos map[*Schema]*resolvedInfo)
 		}
 	}
 	if len(s.PatternProperties) > 0 {
-		info.patternProperties = map[*regexp.Regexp]*Schema{}
+		info.patternProperties = map[Regexp]*Schema{}
 		for reString, subschema := range s.PatternProperties {
-			re, err := regexp.Compile(reString)
+			re, err := compile(reString)
 			if err != nil {
 				addf("patternProperties[%q]: %v", reString, err)
 				continue

--- a/jsonschema/resolve_test.go
+++ b/jsonschema/resolve_test.go
@@ -14,6 +14,10 @@ import (
 	"testing"
 )
 
+var defaultRegexpCompiler RegexpCompiler = func(pattern string) (Regexp, error) {
+	return regexp.Compile(pattern)
+}
+
 func TestSchemaStructure(t *testing.T) {
 	check := func(s *Schema, want string) {
 		t.Helper()
@@ -203,7 +207,7 @@ func TestResolveURIs(t *testing.T) {
 			}
 
 			rs := newResolved(root)
-			if err := root.check(rs.resolvedInfos); err != nil {
+			if err := root.check(rs.resolvedInfos, defaultRegexpCompiler); err != nil {
 				t.Fatal(err)
 			}
 			if err := resolveURIs(rs, base); err != nil {
@@ -251,6 +255,72 @@ func TestResolveURIs(t *testing.T) {
 			}
 		})
 	}
+}
+
+var _ Regexp = alwaysMatch{}
+
+type alwaysMatch struct{}
+
+func (alwaysMatch) MatchString(string) bool { return true }
+
+func TestCustomRegexpCompiler(t *testing.T) {
+	always := func(string) (Regexp, error) {
+		return alwaysMatch{}, nil
+	}
+
+	t.Run("pattern uses custom compiler", func(t *testing.T) {
+		// "pattern" should fail with standard regexp (value doesn't match),
+		// but pass with alwaysMatch.
+		s := &Schema{
+			Type:    "string",
+			Pattern: "^foo$",
+		}
+		rs, err := s.Resolve(&ResolveOptions{RegexpCompiler: always})
+		if err != nil {
+			t.Fatal(err)
+		}
+		// "bar" does not match ^foo$ but alwaysMatch accepts everything.
+		if err := rs.Validate("bar"); err != nil {
+			t.Errorf("expected validation to pass with custom compiler, got: %v", err)
+		}
+	})
+
+	t.Run("patternProperties uses custom compiler", func(t *testing.T) {
+		// With standard regexp "^x" matches "x1", but alwaysMatch matches every key.
+		s := &Schema{
+			Type: "object",
+			PatternProperties: map[string]*Schema{
+				"^x": {Type: "integer"},
+			},
+		}
+		rs, err := s.Resolve(&ResolveOptions{RegexpCompiler: always})
+		if err != nil {
+			t.Fatal(err)
+		}
+		// "other" key would not match "^x" normally, but alwaysMatch makes it match.
+		// Since alwaysMatch matches, the value must satisfy {type: integer}.
+		err = rs.Validate(map[string]any{"other": "not-an-int"})
+		if err == nil {
+			t.Error("expected validation error because alwaysMatch matched patternProperties")
+		}
+	})
+
+	t.Run("compiler error is propagated", func(t *testing.T) {
+		failing := func(pattern string) (Regexp, error) {
+			return nil, errors.New("custom compile error")
+		}
+		s := &Schema{
+			Type:    "string",
+			Pattern: "anything",
+		}
+		_, err := s.Resolve(&ResolveOptions{RegexpCompiler: failing})
+		if err == nil {
+			t.Fatal("expected error from failing compiler")
+		}
+		if !strings.Contains(err.Error(), "custom compile error") {
+			t.Errorf("expected custom error message, got: %v", err)
+		}
+	})
 }
 
 func TestRefCycle(t *testing.T) {


### PR DESCRIPTION
Allow users to provide a custom regexp compiler via ResolveOptions.RegexpCompiler for PCRE-compatible features like lookahead that Go's regexp package does not support.

The Regexp interface requires only MatchString(string) bool, matching both regexp.Regexp and regexp2/compat.Regexp signatures.

Fixes #72