### PR TITLE
jsonschema: return errors instead of panicking on nil receiver/sub-schema

### DIFF
--- a/jsonschema/resolve.go
+++ b/jsonschema/resolve.go
@@ -150,6 +150,9 @@ type ResolveOptions struct {
 // The schema must not be changed after Resolve is called.
 // The same schema may be resolved multiple times.
 func (root *Schema) Resolve(opts *ResolveOptions) (*Resolved, error) {
+	if root == nil {
+		return nil, errors.New("jsonschema: Resolve called on a nil *Schema")
+	}
 	// There are up to five steps required to prepare a schema to validate.
 	// 1. Load: read the schema from somewhere and unmarshal it.
 	//    This schema (root) may have been loaded or created in memory, but other schemas that
@@ -205,6 +208,9 @@ type resolver struct {
 }
 
 func (r *resolver) resolve(s *Schema, baseURI *url.URL) (*Resolved, error) {
+	if s == nil {
+		return nil, errors.New("jsonschema: cannot resolve a nil sub-schema")
+	}
 	if baseURI.Fragment != "" {
 		return nil, fmt.Errorf("base URI %s must not have a fragment", baseURI)
 	}

--- a/jsonschema/resolve_test.go
+++ b/jsonschema/resolve_test.go
@@ -286,3 +286,17 @@ func TestRefCycle(t *testing.T) {
 	check(schemas["a"], "b")
 	check(schemas["b"], "a")
 }
+
+func TestResolveNilReceiver(t *testing.T) {
+	// Regression for https://github.com/google/jsonschema-go/issues/74:
+	// Resolve must return an error rather than panicking when called on a
+	// nil *Schema.
+	var s *Schema
+	_, err := s.Resolve(nil)
+	if err == nil {
+		t.Fatal("expected error from nil-receiver Resolve, got nil")
+	}
+	if !strings.Contains(err.Error(), "nil") {
+		t.Errorf("expected error to mention nil; got %q", err.Error())
+	}
+}


### PR DESCRIPTION
Fixes #74.

`(*Schema).Resolve` and the recursive `(*resolver).resolve` both dereferenced their schema argument without a nil check. The MCP Go SDK and any caller passing a nil `*Schema` would crash with SIGSEGV at `detectDraft` instead of getting an error back. Add nil-checks at both entry points and a regression test on `Resolve`.