### PR TITLE
infer: Add Schemer interface for self-described types

### DIFF
--- a/jsonschema/infer.go
+++ b/jsonschema/infer.go
@@ -147,6 +147,22 @@ func forType(t reflect.Type, seen map[reflect.Type]bool, ignore bool, schemas ma
 		return cloned, nil
 	}
 
+	// Schemer hook: types can self-describe by implementing JSONSchema. This
+	// is intentionally lower priority than TypeSchemas so callers can override
+	// a type they don't own, and the cost is one interface check per type.
+	if custom := schemerFor(t); custom != nil {
+		cloned := custom.CloneSchemas()
+		if allowNull {
+			if cloned.Type != "" {
+				cloned.Types = []string{"null", cloned.Type}
+				cloned.Type = ""
+			} else if !slices.Contains(cloned.Types, "null") {
+				cloned.Types = append([]string{"null"}, cloned.Types...)
+			}
+		}
+		return cloned, nil
+	}
+
 	var (
 		s   = new(Schema)
 		err error
@@ -393,6 +409,39 @@ func init() {
 	}
 	initialSchemaMap[reflect.TypeFor[big.Rat]()] = ss
 	initialSchemaMap[reflect.TypeFor[big.Float]()] = ss
+}
+
+// Schemer is implemented by types that want to provide an explicit JSON
+// Schema for themselves rather than have one inferred from their Go
+// definition.
+//
+// This is the right hook for "smart wrapper" types whose MarshalJSON emits a
+// primitive (string / number / boolean) and would otherwise be reflected as
+// {type: "object"} - the generator sees the struct fields, not the
+// marshalled form. Examples: decimal / money types backed by a private
+// *big.Int, UUID wrappers, custom time formats.
+//
+// JSONSchema is called on the zero value of the type during schema
+// generation, so it must not depend on instance state. Returning nil falls
+// back to the default reflection-based inference. ForOptions.TypeSchemas
+// takes precedence over Schemer so callers can still override a type they
+// don't control.
+type Schemer interface {
+	JSONSchema() *Schema
+}
+
+var schemerType = reflect.TypeFor[Schemer]()
+
+// schemerFor returns the schema declared by t's JSONSchema method, if any.
+// Methods declared with either a value or pointer receiver are honoured.
+func schemerFor(t reflect.Type) *Schema {
+	switch {
+	case t.Implements(schemerType):
+		return reflect.Zero(t).Interface().(Schemer).JSONSchema()
+	case reflect.PointerTo(t).Implements(schemerType):
+		return reflect.New(t).Interface().(Schemer).JSONSchema()
+	}
+	return nil
 }
 
 // Disallow jsonschema tag values beginning "WORD=", for future expansion.

--- a/jsonschema/infer_test.go
+++ b/jsonschema/infer_test.go
@@ -726,6 +726,81 @@ func falseSchema() *jsonschema.Schema {
 	return &jsonschema.Schema{Not: &jsonschema.Schema{}}
 }
 
+// stringDecimal mimics a third-party "smart wrapper" whose MarshalJSON emits
+// a string. The Go struct has no exported fields, so reflection alone would
+// reflect it as {type: "object"}. JSONSchema is the right hook for these.
+type stringDecimal struct{ raw string }
+
+func (stringDecimal) JSONSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{Type: "string"}
+}
+
+// ptrStringDecimal has the same intent as stringDecimal but declares the
+// method on a pointer receiver, which the Schemer hook must also honour.
+type ptrStringDecimal struct{ raw string }
+
+func (*ptrStringDecimal) JSONSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{Type: "string"}
+}
+
+// nilSchemer returns nil from JSONSchema, which must fall back to default
+// reflection-based inference rather than crash.
+type nilSchemer struct{ A int }
+
+func (nilSchemer) JSONSchema() *jsonschema.Schema { return nil }
+
+func TestForWithSchemer(t *testing.T) {
+	type wrapper struct {
+		Price     stringDecimal
+		PtrPrice  ptrStringDecimal
+		MaybeNil  *stringDecimal
+		Fallback  nilSchemer
+		Many      []stringDecimal
+	}
+
+	s, err := jsonschema.For[wrapper](nil)
+	if err != nil {
+		t.Fatalf("For: %v", err)
+	}
+
+	if got := s.Properties["Price"].Type; got != "string" {
+		t.Errorf("Price.Type = %q, want %q", got, "string")
+	}
+	if got := s.Properties["PtrPrice"].Type; got != "string" {
+		t.Errorf("PtrPrice.Type = %q, want %q", got, "string")
+	}
+	// A pointer to a Schemer type should still defer to the type's schema but
+	// allow null as the outer type is a pointer.
+	if got := s.Properties["MaybeNil"].Types; len(got) != 2 || got[0] != "null" || got[1] != "string" {
+		t.Errorf("MaybeNil.Types = %v, want [null string]", got)
+	}
+	// nilSchemer returns nil from JSONSchema -> falls back to struct inference.
+	if got := s.Properties["Fallback"].Type; got != "object" {
+		t.Errorf("Fallback.Type = %q, want %q (fallback to struct inference)", got, "object")
+	}
+	// Slice items should pick up the Schemer hook on the element type.
+	if got := s.Properties["Many"].Items.Type; got != "string" {
+		t.Errorf("Many.Items.Type = %q, want %q", got, "string")
+	}
+}
+
+func TestForWithSchemerOverriddenByTypeSchemas(t *testing.T) {
+	// TypeSchemas must win over Schemer so callers can force a different
+	// schema for a third-party type they don't control.
+	opts := &jsonschema.ForOptions{
+		TypeSchemas: map[reflect.Type]*jsonschema.Schema{
+			reflect.TypeFor[stringDecimal](): {Type: "integer"},
+		},
+	}
+	s, err := jsonschema.For[struct{ X stringDecimal }](opts)
+	if err != nil {
+		t.Fatalf("For: %v", err)
+	}
+	if got := s.Properties["X"].Type; got != "integer" {
+		t.Errorf("X.Type = %q, want %q (TypeSchemas should override Schemer)", got, "integer")
+	}
+}
+
 func TestDupSchema(t *testing.T) {
 	// Verify that we don't repeat schema contents, even if we clone the actual schemas.
 	type args struct {


### PR DESCRIPTION
Implementation sketch for #77.

## What

Adds a small interface that lets types self-describe their JSON Schema:

```go
type Schemer interface {
    JSONSchema() *Schema
}
```

If a type (or `*T`) implements `Schemer`, `For`/`ForType` use the returned schema instead of inferring one from the Go struct. Returning `nil` falls back to default inference. `ForOptions.TypeSchemas` still takes precedence, so callers can override a third-party type they don't control.

## Why

Library types whose `MarshalJSON` emits a JSON primitive (string / number / boolean) currently render as `{type: "object"}` because the generator inspects the Go struct definition rather than the marshalled form. Examples in the wild: `decimal.Decimal` from `github.com/luno/luno-go/decimal`, UUID wrappers, custom time formats, money types.

The library already special-cases `time.Time`, `slog.Level`, `big.Int`, `big.Rat`, `big.Float` via `initialSchemaMap`. `Schemer` generalises that pattern so type authors can opt in once and downstream consumers get the right schema for free.

The concrete failure that motivated this: an MCP server using `mcp-go`'s `WithOutputSchema[T]` (which calls `jsonschema.For[T]`) had every order book entry rejected by strict clients with `data/asks/0/price must be object`, because `decimal.Decimal` reflected as object. See [luno/luno-mcp#128](https://github.com/luno/luno-mcp/pull/128) for the downstream workaround using `ForOptions.TypeSchemas`.

## Behaviour

- `T` implementing `Schemer` with a value receiver → uses the returned schema.
- `*T` implementing `Schemer` with a pointer receiver → same.
- `JSONSchema()` returning `nil` → falls back to default reflection (no panic).
- `*T` field where `T` implements `Schemer` → schema is null-wrapped (`["null", "string"]` etc.), matching how the existing `initialSchemaMap` lookup behaves for pointers.
- `[]T` where `T` implements `Schemer` → items schema comes from `Schemer`.
- `ForOptions.TypeSchemas[T]` set → wins over `Schemer`.

## Tests

`TestForWithSchemer` covers value receiver, pointer receiver, pointer-to-Schemer null-wrapping, nil-return fallback, and slice elements.
`TestForWithSchemerOverriddenByTypeSchemas` covers the precedence rule.

Existing test suite unchanged and green.

## Open questions

1. **Should `JSONSchema()` take a context?** I chose the zero-argument signature for symmetry with `MarshalJSON` and because instance state is meaningless here. Open to passing `*ForOptions` if there's a need.
2. **Should we cache the result per `reflect.Type`?** Each schema generation currently calls `JSONSchema()` once per occurrence of a Schemer type in the tree. Cheap, but cacheable if profiling shows a hot path.
3. **Method name.** `JSONSchema` matches `MarshalJSON`; alternatives are `Schema`, `JSONSchemaFor`, `OpenAPISchemaType`-style. Easy to change.

Happy to iterate.